### PR TITLE
daemon_init: Removed PID check and update

### DIFF
--- a/server/daemon_init.c
+++ b/server/daemon_init.c
@@ -209,12 +209,16 @@ daemon_init(const char *prog, int nofork)
 		exit(1);
 	}
 
-	if (check_process_running(prog, &pid) && (pid != getpid())) {
+/* Prevents multiple instances of the daemon from running.
+    needs to be fixed by the devs.
+*/
+/*	if (check_process_running(prog, &pid) && (pid != getpid())) {
 		syslog(LOG_ERR,
 			"daemon_init: Process \"%s\" already running.\n",
 			prog);
 		exit(1);
 	}
+*/
 
 	if (setup_sigmask() < 0) {
 		syslog(LOG_ERR, "daemon_init: Unable to set signal mask.\n");
@@ -226,7 +230,8 @@ daemon_init(const char *prog, int nofork)
 		exit(1);
 	}
 
-	update_pidfile(prog);
+/*	update_pidfile(prog); */
+
 }
 
 


### PR DESCRIPTION
Hi,

I discovered that it's not possible to run different instances with different configs (and hence for different clusters) with the current version. The reason for that is the broken pid checks that, I imagine, are there to keep different instances of the **same** configuration from running. But in the code, it also prevents **different** configurations from running. It seems that the problem is, that the PID file already exists and the the PID that it contains, points to a still running fence_virtd instance. I commented out the PID file stuff in my branch and now I can run different instances. Please think about pulling in those changes and/or fixing the check in your code base.

Kind regards,
Thermi