### PR TITLE
fence_virtd: Fix segfault in vl_get when no domains are found

### DIFF
--- a/server/virt.c
+++ b/server/virt.c
@@ -128,6 +128,9 @@ virt_list_t *vl_get(virConnectPtr *vp, int vp_count, int my_id)
 
 		_free_dom_list(dom_list, ret);
 	}
+	/* No domains found */
+	if (!vl)
+		return NULL;
 
 	/* We have all the locally running domains & states now */
 	/* Sort */


### PR DESCRIPTION
If virConnectListAllDomains() returns 0 on every iteration, the loop
will end with a vl == NULL and the pointer dereference in the qsort()
call will result in a segfault. Check for NULL on completion of the loop
to guard against that.

NB I haven't tested this patch due to #16 but I'm pretty sure it'll do the trick :) 