### PR TITLE
Fix spelling error in fence_virt.conf.5

### DIFF
--- a/man/fence_virt.conf.5
+++ b/man/fence_virt.conf.5
@@ -119,7 +119,7 @@ is used as a gateway.
 The serial listener plugin utilizes libvirt's serial (or VMChannel)
 mapping to listen for requests.  When using the serial listener, it is
 necessary to add a serial port (preferably pointing to /dev/ttyS1) or
-a channel (preferrably pointing to 10.0.2.179:1229) to the
+a channel (preferably pointing to 10.0.2.179:1229) to the
 libvirt domain description.  Note that only type
 .B unix
 , mode 


### PR DESCRIPTION
preferrably -> preferably